### PR TITLE
remove '$' char from config generate-secret-key

### DIFF
--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -18,7 +18,7 @@ DEFAULT_SETTINGS_OVERRIDE = 'sentry.conf.py'
 
 def generate_secret_key():
     from django.utils.crypto import get_random_string
-    chars = u'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+    chars = u'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)'
     return get_random_string(50, chars)
 
 


### PR DESCRIPTION
Docker-compose complains about '$' in env vars:

`ERROR: Invalid interpolation format for "environment" option in service "base"`